### PR TITLE
Compile ac_math with clang

### DIFF
--- a/include/ac_math/ac_determinant.h
+++ b/include/ac_math/ac_determinant.h
@@ -214,14 +214,14 @@ namespace ac_math
 
       temp_type temp;
       // PIVOT loop to keep track of pivot (element about which minor is to be computed)
-#pragma unroll yes
+#pragma hls_unroll yes
       PIVOT:
       for (unsigned j=0; j<M; j++) {
         // ROW and COLUMN loop to create matrices
-#pragma unroll yes
+#pragma hls_unroll yes
         ROW:
         for (unsigned p=1; p<M; p++) {
-#pragma unroll yes
+#pragma hls_unroll yes
           COLUMN:
           for (unsigned q=1; q<M; q++) {
             b(p-1, q-1) = A(p, q-(q<=j));
@@ -234,7 +234,7 @@ namespace ac_math
         c[j] = pr * temp;
       }
       // Accumulate loop for accumulation after multiplication with pivot
-#pragma unroll yes
+#pragma hls_unroll yes
       ACCUMULATE:
       for (unsigned j=0; j<M; j++) {
         d = d + A(0,j) * c[j];
@@ -411,10 +411,10 @@ namespace ac_math
   {
     ac_matrix < ac_fixed <W1, I1, S1, q1, o1>, M, M > a_temp;
 
-#pragma unroll yes
+#pragma hls_unroll yes
     ROW_CPY:
     for (unsigned i = 0; i < M; i++) {
-#pragma unroll yes
+#pragma hls_unroll yes
       COLUMN_CPY:
       for (unsigned j = 0; j < M; j++) {
         a_temp (i,j) = a[i][j];
@@ -427,10 +427,10 @@ namespace ac_math
   void ac_determinant (const ac_complex <ac_fixed <W1, I1, S1, q1, o1> > a[M][M], ac_complex <ac_fixed <W2, I2, true, q2, o2> > &result)
   {
     ac_matrix < ac_complex <ac_fixed <W1, I1, S1, q1, o1> >, M, M > a_temp;
-#pragma unroll yes
+#pragma hls_unroll yes
     ROW_CPY:
     for (unsigned i = 0; i < M; i++) {
-#pragma unroll yes
+#pragma hls_unroll yes
       COLUMN_CPY:
       for (unsigned j = 0; j < M; j++) {
         a_temp (i,j) = a[i][j];

--- a/include/ac_math/ac_pow_pwl.h
+++ b/include/ac_math/ac_pow_pwl.h
@@ -296,7 +296,7 @@ namespace ac_math
   {
     const ac_fixed<17, 3, true> log2e = 1.44269504089;
     // Find type of intermediate variable used to store output of x*log2(e)
-    typedef class comp_pii_exp<W, I, S, Q, O, n_f_b>::pit_t input_inter_type;
+    typedef typename comp_pii_exp<W, I, S, Q, O, n_f_b>::pit_t input_inter_type;
     input_inter_type input_inter;
     // e^x = 2^(x*log2(e))
     input_inter = input*log2e;

--- a/include/ac_math/ac_sqrt_pwl.h
+++ b/include/ac_math/ac_sqrt_pwl.h
@@ -457,14 +457,14 @@ namespace ac_math
   void ac_sqrt_pwl (const ac_complex <ac_fixed <W, I, true, Q, O> > input,  ac_complex <ac_fixed <outW, outI, true, outQ, outO> > &output)
   {
     // Calculate parameterized bitwidths for all intermediate types.
-    typedef class find_rt_sqrt_pwl<(2*(W - I)), (2*I - 1)>::rt_sqrt_pwl sqrt_mod_type;
+    typedef typename find_rt_sqrt_pwl<(2*(W - I)), (2*I - 1)>::rt_sqrt_pwl sqrt_mod_type;
     const int W1 = sqrt_mod_type::width;
     const int I1 = sqrt_mod_type::i_width;
     const int n_f_b_1 = W1 - I1;
     const int t_I = I + 1;
     const int t_n_f_b = (W - I) > n_f_b_1 ? W - I : n_f_b_1;
     const int t_W = t_I + t_n_f_b;
-    typedef class find_rt_sqrt_pwl<t_W, t_I - 1>::rt_sqrt_pwl x_y_type;
+    typedef typename find_rt_sqrt_pwl<t_W, t_I - 1>::rt_sqrt_pwl x_y_type;
     const int W2 = x_y_type::width;
     const int I2 = x_y_type::i_width;
 


### PR DESCRIPTION
A set of changes to make `ac_math` based code (e.g., the test drivers under `tests`) to work with `clang-8`, `clang-9` and `clang-10` (other `clang` versions will likely work but are not tested).

Local testing used `GCC_EXEC = clang++` and ran all `ac_math` tests which concluded with 
```
=============================================================================
  Testbench finished. Maximum errors observed across all data type / bit-width variations:
    max_error_fixed       = 0.0994861
    cmplx_max_error_fixed = 2.23468
    max_error_float       = 0.100706
  ac_sqrt_pwl - PASSED
=============================================================================
```

meaning the last test (as well as all the previous tests) passed.

The changes are known to work a number of `g++` versions (all versions tested) but they have not been tested with the EDG compiler frontend.