### PR TITLE
change class to typename in typedef

### DIFF
--- a/include/ac_math/ac_chol_d.h
+++ b/include/ac_math/ac_chol_d.h
@@ -188,7 +188,7 @@ namespace ac_math
     T_out L_imd_1D[L_IMD_SIZE];
     // Define type for the intermediate variables
     // Add an extra bit to W and I for intermediate variable type if the output is unsigned, and make sure that i_s_t is signed.
-    typedef class ac_fixed<outW + delta_w, outI + delta_i, true, imd_Q, imd_O> i_s_t;
+    typedef typename ac_fixed<outW + delta_w, outI + delta_i, true, imd_Q, imd_O> i_s_t;
     // Unsigned versions of i_s_t and T_out
     typedef ac_fixed<outW, outI, false, outQ, outO> T_out_u;
     typedef ac_fixed<i_s_t::width, i_s_t::i_width, false, i_s_t::q_mode, i_s_t::o_mode> i_s_t_u;
@@ -354,7 +354,7 @@ namespace ac_math
     typedef ac_int<ac::nbits<L_IMD_SIZE - 1>::val, false> t_1D;
     T_out L_imd_1D[L_IMD_SIZE];
     // Define type for the intermediate variables
-    typedef class ac_float<outW + delta_w, outI + delta_i, outE + delta_e, imd_Q> T_imd;
+    typedef typename ac_float<outW + delta_w, outI + delta_i, outE + delta_e, imd_Q> T_imd;
 
     ARRAY_AC_FLOAT_L_COL:
     for (index_type j = 0; j < M; j++) {

--- a/include/ac_math/ac_pow_pwl.h
+++ b/include/ac_math/ac_pow_pwl.h
@@ -291,12 +291,12 @@ namespace ac_math
     
     #ifdef AC_POW_PWL_CHANGE_FRAC_BITS
     // Find type of intermediate variable used to store output of x*log2(e)
-    typedef class comp_pii_exp<W, I, S, n_f_b>::pit_t input_inter_type;
+    typedef typename comp_pii_exp<W, I, S, n_f_b>::pit_t input_inter_type;
     #else
     const bool is_n_seg_po2 = !bool(n_segments_lut & n_segments_lut - 1);
     const int extra_f_bits = is_n_seg_po2 ? ac::nbits<n_segments_lut - 1>::val : 0;
     // Find type of intermediate variable used to store output of x*log2(e)
-    typedef class comp_pii_exp<W, I, S, n_frac_bits + extra_f_bits>::pit_t input_inter_type;
+    typedef typename comp_pii_exp<W, I, S, n_frac_bits + extra_f_bits>::pit_t input_inter_type;
     #endif
     
     input_inter_type input_inter;

--- a/include/ac_math/ac_sqrt_pwl.h
+++ b/include/ac_math/ac_sqrt_pwl.h
@@ -513,14 +513,14 @@ namespace ac_math
   void ac_sqrt_pwl (const ac_complex <ac_fixed <W, I, true, Q, O> > input,  ac_complex <ac_fixed <outW, outI, true, outQ, outO> > &output)
   {
     // Calculate parameterized bitwidths for all intermediate types.
-    typedef class find_rt_sqrt_pwl<(2*(W - I)), (2*I - 1)>::rt_sqrt_pwl sqrt_mod_type;
+    typedef typename find_rt_sqrt_pwl<(2*(W - I)), (2*I - 1)>::rt_sqrt_pwl sqrt_mod_type;
     const int W1 = sqrt_mod_type::width;
     const int I1 = sqrt_mod_type::i_width;
     const int n_f_b_1 = W1 - I1;
     const int t_I = I + 1;
     const int t_n_f_b = (W - I) > n_f_b_1 ? W - I : n_f_b_1;
     const int t_W = t_I + t_n_f_b;
-    typedef class find_rt_sqrt_pwl<t_W, t_I - 1>::rt_sqrt_pwl x_y_type;
+    typedef typename find_rt_sqrt_pwl<t_W, t_I - 1>::rt_sqrt_pwl x_y_type;
     const int W2 = x_y_type::width;
     const int I2 = x_y_type::i_width;
 


### PR DESCRIPTION
I believe this change is needed for strict C++ compatibility, to identify to treat a value as a typenane. I think one needs to use `typename` in this case and not `class`. Clang on the Mac complains without this change, though I only tested it for `ac_pow_pwl`.